### PR TITLE
Add a couple extra impls to `Secret<T>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,13 @@ impl<T: Hash> Hash for Secret<T> {
     }
 }
 
+impl<T: Default> Default for Secret<T> {
+    #[inline]
+    fn default() -> Secret<T> {
+        Secret(T::default())
+    }
+}
+
 impl<T: Copy> Copy for Secret<T> {}
 impl<T: Eq> Eq for Secret<T> {}
 unsafe impl<T: Sync> Sync for Secret<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ extern crate serde;
 mod tests;
 
 use core::fmt;
+use core::hash::{Hash, Hasher};
 
 #[cfg(feature = "diesel_sql")]
 use std::io::Write;
@@ -219,8 +220,15 @@ impl<T: Clone> Clone for Secret<T> {
 
 impl<T: PartialEq> PartialEq for Secret<T> {
     #[inline]
-    fn partial_eq(&self, other: &Secret<T>) -> Self {
-        self.0.partial_eq(other.0)
+    fn eq(&self, other: &Secret<T>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T: Hash> Hash for Secret<T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ mod tests;
 
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use core::cmp::Ordering;
 
 #[cfg(feature = "diesel_sql")]
 use std::io::Write;
@@ -225,6 +226,20 @@ impl<T: PartialEq> PartialEq for Secret<T> {
     }
 }
 
+impl<T: PartialOrd> PartialOrd for Secret<T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Secret<T>) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<T: Ord> Ord for Secret<T> {
+    #[inline]
+    fn cmp(&self, other: &Secret<T>) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
 impl<T: Hash> Hash for Secret<T> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -233,6 +248,7 @@ impl<T: Hash> Hash for Secret<T> {
 }
 
 impl<T: Copy> Copy for Secret<T> {}
+impl<T: Eq> Eq for Secret<T> {}
 unsafe impl<T: Sync> Sync for Secret<T> {}
 unsafe impl<T: Send> Send for Secret<T> {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,13 @@ impl<T: Clone> Clone for Secret<T> {
     }
 }
 
+impl<T: PartialEq> PartialEq for Secret<T> {
+    #[inline]
+    fn partial_eq(&self, other: &Secret<T>) -> Self {
+        self.0.partial_eq(other.0)
+    }
+}
+
 impl<T: Copy> Copy for Secret<T> {}
 unsafe impl<T: Sync> Sync for Secret<T> {}
 unsafe impl<T: Send> Send for Secret<T> {}


### PR DESCRIPTION
This adds a couple extra impls to `Secret<T>` to make it easier to use.

My thoughts are adding `Hash` and `PartialEq` shouldn't really be a problem because this crate is more targeted towards shielding secret values from accidentally being written to logs, not for protecting the secret value from people who have access to the object from code (I can just `transmute` a `Secret<T>` to `T` after all).