### PR TITLE
Remove `Display` and `ToString` footgun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Note: This version was not released on `crates.io`, as it depends on an unreleas
 - Rename the `serialize`/`deserialize` feature to `serde`.
 - Rename the `diesel_sql` feature to `diesel`.
 
+### Removed
+
+- Remove implementation of `Display` for `Secret`.
+
 ## [1.0.0] - 2021-04-05
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! This will yield the following output:
 //!
 //! ```raw
-//! Now talking to: User{ id = 1, username: String("alice"), session_token: "..." }
+//! Now talking to: User { id = 1, username: String("alice"), session_token: "..." }
 //! ```
 //!
 //! This functionality is very useful when dealing with data that should always be prevented from
@@ -85,8 +85,8 @@
 //! Limited support for inserting and loading `Secret<T>` values through
 //! [Diesel](https://crates.io/crates/diesel) can be enabled by the `diesel` feature.
 //!
-//! **IMPORTANT**: The database may log and echo back (on error) any query that fails, takes to long
-//! or is otherwise deemed interesting. Using `Secret` values in expressions should be avoided.
+//! **IMPORTANT**: The database may log and echo back (on error) any query that fails, takes too
+//! long or is otherwise deemed interesting. Using `Secret` values in expressions should be avoided.
 //!
 //! ## Rocket support (`rocket` feature)
 //!
@@ -223,13 +223,6 @@ impl<T> Secret<T> {
 }
 
 impl<T> fmt::Debug for Secret<T> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "...")
-    }
-}
-
-impl<T: fmt::Display> fmt::Display for Secret<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "...")

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,15 +23,7 @@ fn test_hidden_debug_composite() {
     };
 
     assert_eq!("PublicStruct { secret_field: ... }", format!("{:?}", data));
-}
-
-#[test]
-fn test_hidden_display() {
-    let data = PublicStruct {
-        secret_field: "THIS-SHOULD-BE-SECRET".to_owned().into(),
-    };
-
-    assert_eq!("...", format!("{}", data.secret_field));
+    assert_eq!("...", format!("{:?}", data.secret_field));
 }
 
 #[test]
@@ -39,9 +31,7 @@ fn test_non_str_type() {
     let data: Secret<usize> = Secret::new(42);
     let data_ref: Secret<&usize> = data.as_ref();
 
-    assert_eq!("...", format!("{}", data));
     assert_eq!("...", format!("{:?}", data));
-    assert_eq!("...", format!("{}", data_ref));
     assert_eq!("...", format!("{:?}", data_ref));
 }
 
@@ -49,7 +39,7 @@ fn test_non_str_type() {
 fn test_hidden_debug() {
     let data = Secret::new("THIS-SHOULD-BE-SECRET");
 
-    assert_eq!("...", format!("{}", data));
+    assert_eq!("...", format!("{:?}", data));
 }
 
 #[test]
@@ -57,7 +47,6 @@ fn test_as_str() {
     let data: Secret<String> = Secret::new("THIS-SHOULD-BE-SECRET".into());
     let data_str: Secret<&str> = data.as_str();
 
-    assert_eq!("...", format!("{}", data_str));
     assert_eq!("...", format!("{:?}", data_str));
 }
 
@@ -66,7 +55,6 @@ fn test_static_strings() {
     // test static strings as well
     let data: Secret<&'static str> = Secret::new("THIS-SHOULD-BE-SECRET");
 
-    assert_eq!("...", format!("{}", data));
     assert_eq!("...", format!("{:?}", data));
 }
 
@@ -83,7 +71,6 @@ fn test_as_ref() {
     let data: Secret<String> = Secret::new("THIS-SHOULD-BE-SECRET".into());
     let data_str: Secret<&String> = data.as_ref();
 
-    assert_eq!("...", format!("{}", data_str));
     assert_eq!("...", format!("{:?}", data_str));
 }
 
@@ -92,7 +79,6 @@ fn test_as_mut() {
     let mut data: Secret<String> = Secret::new("THIS-SHOULD-BE-SECRET".into());
     let data_str: Secret<&mut String> = data.as_mut();
 
-    assert_eq!("...", format!("{}", data_str));
     assert_eq!("...", format!("{:?}", data_str));
 }
 


### PR DESCRIPTION
`Display` and `ToString` are implemented for every `Secret<T>` for which `T` implements `Display`. This was removed since a secret is something you usually don't want to display and `to_string()` being available for a secret is somewhat of a footgun.